### PR TITLE
Fix crash caused by calling entries on a file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ fn is_installer(filepath: &Path) -> bool {
 fn games_iter(root: &Path) -> impl Iterator<Item = Game> + '_ {
     entries(root)
         .into_iter()
+        .filter(|e| e.is_dir())
         .filter(move |e| !ignore(&root.join(e)))
         .map(move |e| Game::from_path(root.join(e)))
 }


### PR DESCRIPTION
games iterator could of had a file.
which caused a crash when calling ignore.